### PR TITLE
503 - fix description in the module openy_media_document

### DIFF
--- a/modules/openy_features/openy_media/modules/openy_media_document/config/install/field.field.media.document.field_media_tags.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_document/config/install/field.field.media.document.field_media_tags.yml
@@ -10,7 +10,7 @@ field_name: field_media_tags
 entity_type: media
 bundle: document
 label: 'Media Tags'
-description: ''
+description: 'You can add Media Tags from appropriate vocabulary'
 required: false
 translatable: true
 default_value: {  }


### PR DESCRIPTION
## Steps for review

- [ ] Please provide steps for review here.

- [ ]  login as admin
- [ ]  go to the /admin/structure/media/manage/document/fields/media.document.field_media_tags
- [ ]  check for exist description field and help text for it